### PR TITLE
Fix SelectByTicket for position if selection fails

### DIFF
--- a/MQL_Easy/Position/Includes/PositionMT4.mqh
+++ b/MQL_Easy/Position/Includes/PositionMT4.mqh
@@ -135,9 +135,9 @@ bool CPosition::SelectByTicket(long ticketPar)
       return true;
    }
    else{
+      this.ValidSelection = false;
       string msgTemp = "The Position WAS NOT Selected.";
       return this.Error.CreateErrorCustom(msgTemp,true,false,(__FUNCTION__));
-      this.ValidSelection = false;
    }
 }
 

--- a/MQL_Easy/Position/Includes/PositionMT5.mqh
+++ b/MQL_Easy/Position/Includes/PositionMT5.mqh
@@ -141,9 +141,9 @@ bool CPosition::SelectByTicket(long ticketPar)
       return true;
    }
    else{
+      this.ValidSelection = false;
       string msgTemp = "The Position WAS NOT Selected.";
       return this.Error.CreateErrorCustom(msgTemp,true,false,(__FUNCTION__));
-      this.ValidSelection = false;
    }
 }
 


### PR DESCRIPTION
The ValidSelection property is set to false after the function returns. This could possibly cause problems in some situations.